### PR TITLE
feat: Hermes adapter (docs + starter skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
 
 [看效果](#效果示例) · [安装](#安装) · [它蒸馏了什么](#女娲蒸馏了什么) · [工作原理](#工作原理)
 
+## Hermes 适配（非 Claude Code 用户）
+
+如果你使用的是 Hermes（而不是 Claude Code / skills.sh），请看：
+
+- `hermes/README_HERMES.md`
+
 <br>
 
 **其他语言 / Other Languages:**

--- a/hermes/README_HERMES.md
+++ b/hermes/README_HERMES.md
@@ -1,0 +1,54 @@
+# Nuwa Skill — Hermes Adapter
+
+这份适配层的目标：**不破坏 Claude Code / skills.sh 的原用法**，同时让你在 **Hermes** 里也能用“女娲造人术”的流程与产物。
+
+## 你将得到什么
+
+- 仍然可以在 Claude Code 中：`npx skills add alchaincyf/nuwa-skill`
+- 在 Hermes 中：
+  1) 运行一个“女娲-造人物”的 Hermes 技能（本适配层提供）
+  2) 输出一个人物视角 Skill 到 `~/.hermes/skills/<person>-perspective/`
+  3) 以后在 Hermes 里直接 `skill_view/skill_manage` 调用该人物 Skill
+
+## Hermes 使用方式（推荐）
+
+### 0. 前置
+
+- 你需要能在 Hermes 里调用 `skill_manage`（创建/写入 skill）
+- 你需要能上网（用于调研），或提供本地一手资料（更强）
+
+### 1) 安装（把适配 skill 加进 Hermes）
+
+把本仓库的 `hermes/skills/nuwa-hermes-adapter` 目录拷贝到你的 Hermes skills 目录：
+
+- 目标目录：`~/.hermes/skills/nuwa-hermes-adapter/`
+
+（如果你在本机运行 Hermes：直接复制粘贴目录即可）
+
+### 2) 造一个人物 Skill
+
+在 Hermes 对话里输入类似：
+
+- 「蒸馏：张小龙」
+- 「造一个 Naval 的视角 skill」
+- 「更新：芒格」
+
+适配 skill 会：
+- 兼容 nuwa 的方法论（采集→验证→提炼→生成）
+- 将人物 skill 输出为 Hermes 可加载格式
+
+### 3) 使用人物视角
+
+造完后，你会有一个新 skill，例如：
+- `~/.hermes/skills/zhang-xiaolong-perspective/SKILL.md`
+
+然后在 Hermes 里：
+- `skill_view(name="zhang-xiaolong-perspective")`
+
+## Claude Code / skills.sh 兼容性说明
+
+nuwa 原始流程会写到 `.claude/skills/<person>-perspective/`。
+
+Hermes 适配层会把输出位置改为 `~/.hermes/skills/<person>-perspective/`。
+
+两套输出互不影响。

--- a/hermes/skills/nuwa-hermes-adapter/SKILL.md
+++ b/hermes/skills/nuwa-hermes-adapter/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: nuwa-hermes-adapter
+version: 0.1.0
+source: https://github.com/alchaincyf/nuwa-skill
+adapter_repo: https://github.com/MEJ50749/nuwa-skill
+license: MIT
+---
+
+# 女娲（Hermes 适配层）
+
+目的：把 `alchaincyf/nuwa-skill` 的“蒸馏人物→生成可运行 skill”的方法论，适配到 Hermes 的 skill 体系中。
+
+## 你说一句话就能触发
+
+- 「女娲，蒸馏张小龙」
+- 「造一个 Naval 视角 skill」
+- 「更新芒格的 skill」
+
+## 输出
+
+- 新建/更新 Hermes skill：`~/.hermes/skills/<person>-perspective/SKILL.md`
+
+## 执行步骤（Hermes Agent）
+
+1) 识别用户输入：
+   - 明确人名：直接蒸馏
+   - 模糊需求：先用 1-2 个追问定位维度，再推荐 1-3 个候选人物，用户选定后蒸馏
+
+2) 采集语料（六路并行思想，但在 Hermes 中可串行执行）：
+   - 著作/文章
+   - 访谈/播客
+   - 社交媒体/公开讲话
+   - 批评者视角
+   - 决策记录/案例
+   - 人生时间线
+
+3) 三重验证提炼（收录为心智模型的准入门槛）：
+   - 跨 2+ 领域出现
+   - 能推断对新问题立场（预测力）
+   - 具排他性（不是人人都这么想）
+
+4) 生成人物 Skill（Hermes 兼容格式）：
+   - 3-7 心智模型
+   - 5-10 决策启发式
+   - 表达 DNA
+   - 价值观/反模式
+   - 诚实边界
+   - 3 个公开问答回测 + 1 个未知问题的不确定性测试
+
+5) 写入 skill：
+   - skill 名：`<slug>-perspective`
+   - 用 `skill_manage(action='create', name=..., content=...)` 创建
+
+## 产物模板（生成的 SKILL.md 必须包含）
+
+- YAML frontmatter：name / description / triggers（可选）
+- 使用方式：
+  - “用 XX 视角分析/解释/决策”
+  - “当我输入材料 A 时，XX 会如何提问/拆解”
+- 诚实边界：哪些问题它不该装懂
+
+## 注意
+
+- 不要冒充本人。明确：这是对其公开思维方式的蒸馏。
+- 遇到缺乏材料或冲突材料：给出不确定性，并标注依据来源类型。


### PR DESCRIPTION
Adds Hermes adapter entrypoint without breaking existing Claude Code/skills.sh usage.

- Add  with Hermes usage
- Add starter Hermes skill: 
- Link from main README

This is a minimal first step; follow-up PR can add conversion script + full generation pipeline.