### PR TITLE
fix: create timestamp marker before subtitle download

### DIFF
--- a/scripts/download_subtitles.sh
+++ b/scripts/download_subtitles.sh
@@ -24,7 +24,7 @@ echo ">>> 尝试下载人工字幕（中文优先）..."
 
 # 尝试1: 人工中文字幕
 if yt-dlp --write-subs --sub-langs "zh-Hans,zh-Hant,zh,zh-CN,zh-TW" --sub-format srt --skip-download -o "$OUTPUT_DIR/%(title)s" "$URL" 2>/dev/null; then
-    FOUND=$(find "$OUTPUT_DIR" -name "*.srt" -newer /tmp/.ytdlp_marker 2>/dev/null | head -1)
+    FOUND=$(find "$OUTPUT_DIR" -name "*.srt" -newer $MARKER 2>/dev/null | head -1)
     if [ -n "$FOUND" ]; then
         echo "✅ 下载成功: $FOUND"
         exit 0


### PR DESCRIPTION
The `download_subtitles.sh` script uses `find -newer /tmp/.ytdlp_marker` to detect newly downloaded files, but `/tmp/.ytdlp_marker` was never created — the marker comparison silently failed.

Fix: create a temporary marker file before the first yt-dlp call so `find -newer` works correctly.