### PR TITLE
fix README: 修复已损坏的 Star History 图表，五语 README 同步切换

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 <br>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.com/#alchaincyf/nuwa-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.dera.page/#alchaincyf/nuwa-skill&Date)
 
 </div>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -242,7 +242,7 @@ All research is fully transparent. The examples include complete research files 
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.com/#alchaincyf/nuwa-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.dera.page/#alchaincyf/nuwa-skill&Date)
 
 </div>
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -244,7 +244,7 @@ Toda la investigación es completamente transparente. Los ejemplos incluyen arch
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.com/#alchaincyf/nuwa-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.dera.page/#alchaincyf/nuwa-skill&Date)
 
 </div>
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -245,7 +245,7 @@ nuwa-skill/
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.com/#alchaincyf/nuwa-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.dera.page/#alchaincyf/nuwa-skill&Date)
 
 </div>
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -244,7 +244,7 @@ nuwa-skill/
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.com/#alchaincyf/nuwa-skill&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=alchaincyf/nuwa-skill&type=Date)](https://star-history.dera.page/#alchaincyf/nuwa-skill&Date)
 
 </div>
 


### PR DESCRIPTION
当前 README 里的 Star History 星标趋势图因 GitHub stargazer API 限制已经打不开了，仓库的 Star 增长情况无法直观展示。本 PR 把中/EN/JA/KO/ES 五语 README 的图表链接统一切换到修复后的 star-history.dera.page，让图表恢复正常显示。